### PR TITLE
fix dmj 5_14 markdonw error

### DIFF
--- a/orid/dmj/2017_5_14.md
+++ b/orid/dmj/2017_5_14.md
@@ -1,66 +1,62 @@
 
-#2017年5月14日成都meetup总结帖
-
-```ruby
-我的分享
-```
-
-1.坑：meetup大家推荐的软件没有及时用；
-
-2.概念：即时使用别人推荐的软件 & 多做提取练习（提取练习的次数越多，对新知识的记忆就越巩固。）
+# 2017年5月14日成都meetup总结帖
 
 
+### 我的分享
 
-```ruby
-大家的分享
-```
 
-1.O
+1. 坑：meetup大家推荐的软件没有及时用；
 
-1)限制登陆，除了可以用only以外，也可以用except
-
-before_action: authenticate_user!, except: [:index,:show]
-
-2).同时开两个专案的方法：
-
-$rails s -p 8000
-
-3).相对devise研究得更深入的方法：
-
-看大牛的写的devise视频，然后再去看官方文档。
-
-！安装devise后，rake routes，观察devise后产生的路径，发现产生了很多的controller.
-
-4）非常好用的编辑器：
-
-编辑器：http://markeditor.com/app/markeditor
-
-5）安装这个gem 'awesome_rails_console'可以使 rails c 的输出更利于我们观看。
-
-＃在rails c 中输入 User.first
-
-![](http://ww3.sinaimg.cn/large/006tNc79gy1fflqv02bvij30qo0zk42a.jpg)
-
-＃ 输入 User.all
-
-![](http://ww2.sinaimg.cn/large/006tNc79gy1fflqwvfgxfj30qo0zktci.jpg)
-
-6)学ruby语法的网站：
-
-[https://launchschool.com/exercises#ruby_basics](https://launchschool.com/exercises#ruby_basics)
-
-@解决index 的序号编码错乱问题。
-
-[https://www.codecademy.com/learn/ruby](https://www.codecademy.com/learn/ruby)
-
-![](http://ww4.sinaimg.cn/large/006tNc79gy1ffl03kj54cj30qo0zkgnj.jpg)
+2. 概念：即时使用别人推荐的软件 & 多做提取练习（提取练习的次数越多，对新知识的记忆就越巩固。）
 
 
 
-```ruby
-2.I
-```
+### 大家的分享
 
-1)meetup 的总结帖也需要拿出来复盘一下，这样可以看看哪些用了，哪些没用。
 
-2)参加meetup收获好多，通过大家的分享和讨论，明白了很多教材中的语法问题。
+1. 限制登陆，除了可以用only以外，也可以用except
+	```ruby
+	before_action: authenticate_user!, except: [:index,:show]
+	```
+2. 同时开两个专案的方法：
+
+	`$rails s -p 8000`
+
+3. 相对devise研究得更深入的方法：
+
+	看大牛的写的devise视频，然后再去看官方文档。
+
+	！安装devise后，rake routes，观察devise后产生的路径，发现产生了很多的controller.
+
+4. 非常好用的编辑器：
+
+	[MarkEditor](http://markeditor.com/app/markeditor)
+
+5. 安装这个gem 'awesome_rails_console'可以使 rails c 的输出更利于我们观看。
+
+	* 在rails c 中输入 User.first
+
+		![](http://ww3.sinaimg.cn/large/006tNc79gy1fflqv02bvij30qo0zk42a.jpg)
+
+	* 输入 User.all
+
+		![](http://ww2.sinaimg.cn/large/006tNc79gy1fflqwvfgxfj30qo0zktci.jpg)
+
+6. 学ruby语法的网站：
+	[https://launchschool.com/exercises#ruby_basics](https://launchschool.com/exercises#ruby_basics)
+
+7. 解决index 的序号编码错乱问题。
+
+	[https://www.codecademy.com/learn/ruby](https://www.codecademy.com/learn/ruby)
+
+	![](http://ww4.sinaimg.cn/large/006tNc79gy1ffl03kj54cj30qo0zkgnj.jpg)
+
+
+
+### 感想
+
+1. meetup 的总结帖也需要拿出来复盘一下，这样可以看看哪些用了，哪些没用。
+
+2. 参加meetup收获好多，通过大家的分享和讨论，明白了很多教材中的语法问题。
+
+


### PR DESCRIPTION
#号后面要有空格
markdown还做不到1.0 ,1.1, 1.2这样的写法
`1)` 这样的写法也不太推荐
可以利用多个#号，或者嵌套index的方式来实现

---------

## 多#号（也并不是很推荐，除非你需要很多层级）
* 代码(每个层级跨两个#号，比较明显)：
```
# 一
### 1
##### 1.1
##### 1.2
### 2
# 二
```
* 效果如下
# 一
### 1
##### 1.1
##### 1.2
### 2
# 二

--------
## 嵌套index
* 代码如下
```
1. 大家发言
	* 张三说…
	* 李四说..
2. 我的发言
	1. 关于语法
	2. 关于语法
	3. 关于前端
3. 感想
```
* 效果如下
1. 大家发言
	* 张三说…
	* 李四说..
2. 我的发言
	1. 关于语法
	2. 关于语法
	3. 关于前端
3. 感想


> 注意这个i ii iii这种形式是github渲染出来的不一定都这么显示，一般会直接显示1. 2. 3. ...
